### PR TITLE
Added Message Action

### DIFF
--- a/content/lib/pyswitch/clients/local/actions/message.py
+++ b/content/lib/pyswitch/clients/local/actions/message.py
@@ -1,0 +1,24 @@
+from ....controller.callbacks import Callback
+from ....controller.actions import Action
+
+# Simple action to display a message in a display field
+def DISPLAY_MESSAGE(text, display=None, color=None, id=None, enable_callback=None):
+	return Action({
+		"callback": _DisplayMessageCallback(text=text, color=color),
+		"display": display,
+		"id": id,
+		"enableCallback": enable_callback
+	})
+
+
+class _DisplayMessageCallback(Callback):
+	def __init__(self, text, color=None):
+		super().__init__()
+		self._text = text
+		self._color = color
+
+	def update_displays(self):
+		if self.action and self.action.label:
+			self.action.label.text = self._text
+			if self._color is not None:
+				self.action.label.back_color = self._color


### PR DESCRIPTION
this action allows to set a custom message and color on a display field.
This is particularly useful if you just want to display a text on a field for example with the pager option.
Or in my case don't display anything for the second page of a pager if there's no assigned action.